### PR TITLE
CCC: PR tracking with unified strip and zoom panel

### DIFF
--- a/daemon/internal/ctlserver/handler.go
+++ b/daemon/internal/ctlserver/handler.go
@@ -3,32 +3,39 @@ package ctlserver
 import (
 	"bufio"
 	"encoding/json"
+	"fmt"
 	"log"
 	"net"
+	"strings"
 
 	"github.com/pchaganti/claude-session-manager/daemon/internal/ghostty"
 	"github.com/pchaganti/claude-session-manager/daemon/internal/model"
+	"github.com/pchaganti/claude-session-manager/daemon/internal/pr"
 	"github.com/pchaganti/claude-session-manager/daemon/internal/state"
 )
 
 type ctlRequest struct {
 	Action    string `json:"action"`
 	SessionID string `json:"session_id,omitempty"`
+	PRURL     string `json:"pr_url,omitempty"`     // for add_pr
+	PRKey     string `json:"pr_key,omitempty"`     // "owner/repo#N" for remove_pr
 }
 
 type ctlResponse struct {
 	OK            *bool           `json:"ok,omitempty"`
 	Sessions      []model.Session `json:"sessions,omitempty"`
+	PRs           []pr.TrackedPR  `json:"prs,omitempty"`
 	Event         string          `json:"event,omitempty"`
 	AutopilotMode string          `json:"autopilot_mode,omitempty"`
 }
 
 type Handler struct {
-	state *state.Manager
+	state  *state.Manager
+	prPoll *pr.Poller
 }
 
-func NewHandler(st *state.Manager) *Handler {
-	return &Handler{state: st}
+func NewHandler(st *state.Manager, prPoll *pr.Poller) *Handler {
+	return &Handler{state: st, prPoll: prPoll}
 }
 
 func (h *Handler) Handle(conn net.Conn) {
@@ -57,22 +64,43 @@ func (h *Handler) Handle(conn net.Conn) {
 			h.handleReject(conn, req.SessionID)
 		case "approve_all":
 			h.handleApproveAll(conn)
+		case "add_pr":
+			h.handleAddPR(conn, req.PRURL)
+		case "remove_pr":
+			h.handleRemovePR(conn, req.PRKey)
 		}
 	}
 }
 
 func (h *Handler) handleList(conn net.Conn) {
-	writeJSON(conn, ctlResponse{Sessions: h.state.GetSessions()})
+	var prs []pr.TrackedPR
+	if h.prPoll != nil {
+		prs = h.prPoll.GetAll()
+	}
+	writeJSON(conn, ctlResponse{Sessions: h.state.GetSessions(), PRs: prs})
 }
 
 func (h *Handler) handleSubscribe(conn net.Conn) {
 	ch := h.state.Subscribe()
 	defer h.state.Unsubscribe(ch)
 
-	writeJSON(conn, ctlResponse{Event: "sessions_updated", Sessions: h.state.GetSessions()})
+	resp := h.stateSnapshot()
+	writeJSON(conn, resp)
 	for range ch {
-		writeJSON(conn, ctlResponse{Event: "sessions_updated", Sessions: h.state.GetSessions()})
+		resp := h.stateSnapshot()
+		writeJSON(conn, resp)
 	}
+}
+
+func (h *Handler) stateSnapshot() ctlResponse {
+	resp := ctlResponse{
+		Event:    "state_updated",
+		Sessions: h.state.GetSessions(),
+	}
+	if h.prPoll != nil {
+		resp.PRs = h.prPoll.GetAll()
+	}
+	return resp
 }
 
 func (h *Handler) handleToggleAutopilot(conn net.Conn, sid string) {
@@ -116,6 +144,52 @@ func (h *Handler) handleApproveAll(conn net.Conn) {
 	if ok {
 		log.Printf("ctl: approve_all — %d sessions", count)
 	}
+	writeJSON(conn, ctlResponse{OK: &ok})
+}
+
+func (h *Handler) handleAddPR(conn net.Conn, url string) {
+	if h.prPoll == nil {
+		f := false
+		writeJSON(conn, ctlResponse{OK: &f})
+		return
+	}
+	tracked, err := h.prPoll.AddFromURL(url)
+	if err != nil {
+		log.Printf("ctl: add_pr failed: %v", err)
+		f := false
+		writeJSON(conn, ctlResponse{OK: &f})
+		return
+	}
+	log.Printf("ctl: added PR %s/%s#%d", tracked.Owner, tracked.Repo, tracked.Number)
+	ok := true
+	writeJSON(conn, ctlResponse{OK: &ok})
+	// Trigger immediate poll for the new PR.
+	go h.prPoll.Poll()
+}
+
+func (h *Handler) handleRemovePR(conn net.Conn, key string) {
+	if h.prPoll == nil {
+		f := false
+		writeJSON(conn, ctlResponse{OK: &f})
+		return
+	}
+	// Parse "owner/repo#N"
+	parts := strings.SplitN(key, "#", 2)
+	if len(parts) != 2 {
+		f := false
+		writeJSON(conn, ctlResponse{OK: &f})
+		return
+	}
+	ownerRepo := strings.SplitN(parts[0], "/", 2)
+	if len(ownerRepo) != 2 {
+		f := false
+		writeJSON(conn, ctlResponse{OK: &f})
+		return
+	}
+	var number int
+	fmt.Sscanf(parts[1], "%d", &number)
+	h.prPoll.Remove(ownerRepo[0], ownerRepo[1], number)
+	ok := true
 	writeJSON(conn, ctlResponse{OK: &ok})
 }
 

--- a/daemon/internal/ctlserver/handler_test.go
+++ b/daemon/internal/ctlserver/handler_test.go
@@ -43,7 +43,7 @@ func sendAndReceive(t *testing.T, conn net.Conn, req ctlRequest) ctlResponse {
 func setupHandler(t *testing.T) (*state.Manager, net.Conn) {
 	t.Helper()
 	st := newTestState(t)
-	h := NewHandler(st)
+	h := NewHandler(st, nil)
 
 	server, client := net.Pipe()
 	go h.Handle(server)

--- a/daemon/internal/ctlserver/server.go
+++ b/daemon/internal/ctlserver/server.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 
+	"github.com/pchaganti/claude-session-manager/daemon/internal/pr"
 	"github.com/pchaganti/claude-session-manager/daemon/internal/state"
 )
 
@@ -17,10 +18,11 @@ const DefaultSocket = "/tmp/csm-ctl.sock"
 type Server struct {
 	listener net.Listener
 	state    *state.Manager
+	prPoll   *pr.Poller
 }
 
 // New creates a control server.
-func New(socketPath string, st *state.Manager) (*Server, error) {
+func New(socketPath string, st *state.Manager, prPoll *pr.Poller) (*Server, error) {
 	_ = os.Remove(socketPath)
 
 	ln, err := net.Listen("unix", socketPath)
@@ -32,6 +34,7 @@ func New(socketPath string, st *state.Manager) (*Server, error) {
 	return &Server{
 		listener: ln,
 		state:    st,
+		prPoll:   prPoll,
 	}, nil
 }
 
@@ -43,7 +46,7 @@ func (s *Server) Serve() {
 		if err != nil {
 			return
 		}
-		h := NewHandler(s.state)
+		h := NewHandler(s.state, s.prPoll)
 		go h.Handle(conn)
 	}
 }

--- a/daemon/internal/pr/model.go
+++ b/daemon/internal/pr/model.go
@@ -1,0 +1,94 @@
+// Package pr manages tracked pull requests — polling, state, and lifecycle.
+package pr
+
+import "time"
+
+// PRState represents the current state of a tracked PR.
+type PRState string
+
+const (
+	StateChecksRunning PRState = "checks_running"
+	StateChecksFailing PRState = "checks_failing"
+	StateChecksPassing PRState = "checks_passing"
+	StateApproved      PRState = "approved"
+	StateMerged        PRState = "merged"
+	StateClosed        PRState = "closed"
+)
+
+// Check represents a CI check result.
+type Check struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`     // "COMPLETED", "IN_PROGRESS", "QUEUED"
+	Conclusion string `json:"conclusion"` // "SUCCESS", "FAILURE", "NEUTRAL", ""
+	Detail     string `json:"detail"`     // failure message if available
+	Duration   string `json:"duration"`   // human-readable
+}
+
+// Review represents a PR reviewer.
+type Review struct {
+	Author  string `json:"author"`
+	State   string `json:"state"` // "APPROVED", "CHANGES_REQUESTED", "COMMENTED", "PENDING"
+	Body    string `json:"body"`
+	At      string `json:"at"` // human-readable time
+}
+
+// PREvent is a timeline entry for the PR.
+type PREvent struct {
+	Time    time.Time `json:"time"`
+	Icon    string    `json:"icon"`
+	Message string    `json:"message"`
+}
+
+// TrackedPR represents a PR being monitored by the daemon.
+type TrackedPR struct {
+	Owner      string    `json:"owner"`
+	Repo       string    `json:"repo"`
+	Number     int       `json:"number"`
+	Title      string    `json:"title"`
+	HeadBranch string    `json:"head_branch"`
+	BaseBranch string    `json:"base_branch"`
+	URL        string    `json:"url"`
+	State      PRState   `json:"state"`
+	Checks     []Check   `json:"checks"`
+	Reviews    []Review  `json:"reviews"`
+	Mergeable  string    `json:"mergeable"` // "MERGEABLE", "CONFLICTING", "UNKNOWN"
+	Additions  int       `json:"additions"`
+	Deletions  int       `json:"deletions"`
+	CommitCount int      `json:"commit_count"`
+	IsDraft    bool      `json:"is_draft"`
+	CreatedAt  time.Time `json:"created_at"`
+	UpdatedAt  time.Time `json:"updated_at"`
+	Timeline   []PREvent `json:"timeline"`
+
+	// Tracking config
+	AutoMerge   bool   `json:"auto_merge"`
+	Hammer      bool   `json:"hammer"`      // auto-fix CI failures
+	HammerCount int    `json:"hammer_count"` // fix attempts so far
+	MergeMethod string `json:"merge_method"` // "squash", "merge", "rebase"
+}
+
+// ChecksSummary returns (passing, total) counts.
+func (pr *TrackedPR) ChecksSummary() (int, int) {
+	passing := 0
+	for _, c := range pr.Checks {
+		if c.Conclusion == "SUCCESS" || c.Conclusion == "NEUTRAL" {
+			passing++
+		}
+	}
+	return passing, len(pr.Checks)
+}
+
+// HasFailingChecks returns true if any check has failed.
+func (pr *TrackedPR) HasFailingChecks() bool {
+	for _, c := range pr.Checks {
+		if c.Conclusion == "FAILURE" {
+			return true
+		}
+	}
+	return false
+}
+
+// NeedsAttention returns true if the PR needs user action.
+func (pr *TrackedPR) NeedsAttention() bool {
+	return pr.State == StateChecksFailing
+}

--- a/daemon/internal/pr/poller.go
+++ b/daemon/internal/pr/poller.go
@@ -1,0 +1,381 @@
+package pr
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Poller fetches PR data from GitHub via the gh CLI.
+type Poller struct {
+	mu       sync.RWMutex
+	tracked  map[string]*TrackedPR // "owner/repo#number" → PR
+	onChange func()                // called when PR state changes
+
+	storePath string // persistence path (~/.csm/prs.json)
+}
+
+// NewPoller creates a PR poller.
+func NewPoller(storePath string, onChange func()) *Poller {
+	p := &Poller{
+		tracked:   make(map[string]*TrackedPR),
+		onChange:  onChange,
+		storePath: storePath,
+	}
+	p.load()
+	return p
+}
+
+// Add starts tracking a PR.
+func (p *Poller) Add(owner, repo string, number int) *TrackedPR {
+	key := fmt.Sprintf("%s/%s#%d", owner, repo, number)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if pr, ok := p.tracked[key]; ok {
+		return pr
+	}
+
+	pr := &TrackedPR{
+		Owner:      owner,
+		Repo:       repo,
+		Number:     number,
+		AutoMerge:  true,
+		Hammer:     true,
+		MergeMethod: "squash",
+		Timeline:   []PREvent{{Time: time.Now(), Icon: "📝", Message: "Added to tracking"}},
+	}
+	p.tracked[key] = pr
+	p.save()
+	if p.onChange != nil {
+		p.onChange()
+	}
+	return pr
+}
+
+// AddFromURL parses a GitHub PR URL and starts tracking.
+func (p *Poller) AddFromURL(url string) (*TrackedPR, error) {
+	// Parse: https://github.com/owner/repo/pull/123
+	url = strings.TrimSpace(url)
+	url = strings.TrimSuffix(url, "/")
+	parts := strings.Split(url, "/")
+	if len(parts) < 5 || parts[len(parts)-2] != "pull" {
+		return nil, fmt.Errorf("invalid PR URL: %s", url)
+	}
+	owner := parts[len(parts)-4]
+	repo := parts[len(parts)-3]
+	var number int
+	if _, err := fmt.Sscanf(parts[len(parts)-1], "%d", &number); err != nil {
+		return nil, fmt.Errorf("invalid PR number in URL: %s", url)
+	}
+	return p.Add(owner, repo, number), nil
+}
+
+// Remove stops tracking a PR.
+func (p *Poller) Remove(owner, repo string, number int) {
+	key := fmt.Sprintf("%s/%s#%d", owner, repo, number)
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	delete(p.tracked, key)
+	p.save()
+	if p.onChange != nil {
+		p.onChange()
+	}
+}
+
+// GetAll returns all tracked PRs.
+func (p *Poller) GetAll() []TrackedPR {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	result := make([]TrackedPR, 0, len(p.tracked))
+	for _, pr := range p.tracked {
+		result = append(result, *pr)
+	}
+	return result
+}
+
+// FailingCount returns how many PRs have failing checks.
+func (p *Poller) FailingCount() int {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	n := 0
+	for _, pr := range p.tracked {
+		if pr.State == StateChecksFailing {
+			n++
+		}
+	}
+	return n
+}
+
+// Poll fetches latest state for all tracked PRs from GitHub.
+func (p *Poller) Poll() {
+	p.mu.RLock()
+	keys := make([]string, 0, len(p.tracked))
+	for k := range p.tracked {
+		keys = append(keys, k)
+	}
+	p.mu.RUnlock()
+
+	changed := false
+	for _, key := range keys {
+		p.mu.RLock()
+		pr, ok := p.tracked[key]
+		if !ok {
+			p.mu.RUnlock()
+			continue
+		}
+		owner, repo, number := pr.Owner, pr.Repo, pr.Number
+		p.mu.RUnlock()
+
+		if p.pollOne(owner, repo, number) {
+			changed = true
+		}
+	}
+	if changed {
+		p.mu.Lock()
+		p.save()
+		p.mu.Unlock()
+		if p.onChange != nil {
+			p.onChange()
+		}
+	}
+}
+
+func (p *Poller) pollOne(owner, repo string, number int) bool {
+	key := fmt.Sprintf("%s/%s#%d", owner, repo, number)
+
+	// Fetch PR data.
+	out, err := exec.Command("gh", "pr", "view",
+		fmt.Sprintf("%d", number),
+		"--repo", fmt.Sprintf("%s/%s", owner, repo),
+		"--json", "title,headRefName,baseRefName,url,state,statusCheckRollup,reviews,latestReviews,mergeable,additions,deletions,commits,isDraft,updatedAt",
+	).Output()
+	if err != nil {
+		log.Printf("pr: gh pr view %s failed: %v", key, err)
+		return false
+	}
+
+	var ghPR ghPRData
+	if err := json.Unmarshal(out, &ghPR); err != nil {
+		log.Printf("pr: parse %s: %v", key, err)
+		return false
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	pr, ok := p.tracked[key]
+	if !ok {
+		return false
+	}
+
+	oldState := pr.State
+
+	// Update fields.
+	pr.Title = ghPR.Title
+	pr.HeadBranch = ghPR.HeadRefName
+	pr.BaseBranch = ghPR.BaseRefName
+	pr.URL = ghPR.URL
+	pr.Mergeable = ghPR.Mergeable
+	pr.Additions = ghPR.Additions
+	pr.Deletions = ghPR.Deletions
+	pr.CommitCount = len(ghPR.Commits)
+	pr.IsDraft = ghPR.IsDraft
+	pr.UpdatedAt = ghPR.UpdatedAt
+
+	// Parse checks.
+	pr.Checks = nil
+	for _, c := range ghPR.StatusCheckRollup {
+		check := Check{
+			Name:       c.Name,
+			Status:     c.Status,
+			Conclusion: c.Conclusion,
+		}
+		if c.CompletedAt != "" && c.StartedAt != "" {
+			// Simple duration calc.
+			start, _ := time.Parse(time.RFC3339, c.StartedAt)
+			end, _ := time.Parse(time.RFC3339, c.CompletedAt)
+			if !start.IsZero() && !end.IsZero() {
+				d := end.Sub(start)
+				if d < time.Minute {
+					check.Duration = fmt.Sprintf("%ds", int(d.Seconds()))
+				} else {
+					check.Duration = fmt.Sprintf("%dm %ds", int(d.Minutes()), int(d.Seconds())%60)
+				}
+			}
+		}
+		pr.Checks = append(pr.Checks, check)
+	}
+
+	// Parse reviews.
+	pr.Reviews = nil
+	for _, r := range ghPR.LatestReviews {
+		review := Review{
+			Author: r.Author.Login,
+			State:  r.State,
+			Body:   r.Body,
+		}
+		if !r.SubmittedAt.IsZero() {
+			ago := time.Since(r.SubmittedAt)
+			if ago < time.Hour {
+				review.At = fmt.Sprintf("%dm ago", int(ago.Minutes()))
+			} else if ago < 24*time.Hour {
+				review.At = fmt.Sprintf("%dh ago", int(ago.Hours()))
+			} else {
+				review.At = fmt.Sprintf("%dd ago", int(ago.Hours()/24))
+			}
+		}
+		pr.Reviews = append(pr.Reviews, review)
+	}
+
+	// Determine state.
+	if ghPR.State == "MERGED" {
+		pr.State = StateMerged
+	} else if ghPR.State == "CLOSED" {
+		pr.State = StateClosed
+	} else {
+		hasRunning := false
+		hasFailing := false
+		for _, c := range pr.Checks {
+			if c.Status == "IN_PROGRESS" || c.Status == "QUEUED" {
+				hasRunning = true
+			}
+			if c.Conclusion == "FAILURE" {
+				hasFailing = true
+			}
+		}
+
+		// Check if approved.
+		hasApproval := false
+		for _, r := range pr.Reviews {
+			if r.State == "APPROVED" {
+				hasApproval = true
+				break
+			}
+		}
+
+		switch {
+		case hasFailing:
+			pr.State = StateChecksFailing
+		case hasRunning:
+			pr.State = StateChecksRunning
+		case hasApproval:
+			pr.State = StateApproved
+		default:
+			pr.State = StateChecksPassing
+		}
+	}
+
+	// Timeline events on state change.
+	if pr.State != oldState && oldState != "" {
+		pr.Timeline = append(pr.Timeline, PREvent{
+			Time:    time.Now(),
+			Icon:    stateIcon(pr.State),
+			Message: fmt.Sprintf("State: %s → %s", oldState, pr.State),
+		})
+	}
+
+	return pr.State != oldState
+}
+
+func stateIcon(s PRState) string {
+	switch s {
+	case StateChecksFailing:
+		return "✗"
+	case StateChecksRunning:
+		return "⏳"
+	case StateChecksPassing:
+		return "✓"
+	case StateApproved:
+		return "✅"
+	case StateMerged:
+		return "🚀"
+	case StateClosed:
+		return "⊘"
+	default:
+		return "•"
+	}
+}
+
+// RunLoop polls PRs on a timer.
+func RunLoop(p *Poller, interval time.Duration, stop <-chan struct{}) {
+	// Initial poll.
+	p.Poll()
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ticker.C:
+			p.Poll()
+		case <-stop:
+			return
+		}
+	}
+}
+
+// --- gh JSON response types ---
+
+type ghPRData struct {
+	Title              string           `json:"title"`
+	HeadRefName        string           `json:"headRefName"`
+	BaseRefName        string           `json:"baseRefName"`
+	URL                string           `json:"url"`
+	State              string           `json:"state"` // "OPEN", "MERGED", "CLOSED"
+	Mergeable          string           `json:"mergeable"`
+	Additions          int              `json:"additions"`
+	Deletions          int              `json:"deletions"`
+	IsDraft            bool             `json:"isDraft"`
+	UpdatedAt          time.Time        `json:"updatedAt"`
+	StatusCheckRollup  []ghCheck        `json:"statusCheckRollup"`
+	LatestReviews      []ghReview       `json:"latestReviews"`
+	Commits            []ghCommit       `json:"commits"`
+}
+
+type ghCheck struct {
+	Name        string `json:"name"`
+	Status      string `json:"status"`
+	Conclusion  string `json:"conclusion"`
+	StartedAt   string `json:"startedAt"`
+	CompletedAt string `json:"completedAt"`
+}
+
+type ghReview struct {
+	Author      ghAuthor  `json:"author"`
+	State       string    `json:"state"`
+	Body        string    `json:"body"`
+	SubmittedAt time.Time `json:"submittedAt"`
+}
+
+type ghAuthor struct {
+	Login string `json:"login"`
+}
+
+type ghCommit struct{}
+
+// --- persistence ---
+
+func (p *Poller) load() {
+	data, err := os.ReadFile(p.storePath)
+	if err != nil {
+		return
+	}
+	var prs map[string]*TrackedPR
+	if err := json.Unmarshal(data, &prs); err != nil {
+		return
+	}
+	p.tracked = prs
+}
+
+func (p *Poller) save() {
+	data, err := json.MarshalIndent(p.tracked, "", "  ")
+	if err != nil {
+		return
+	}
+	_ = os.WriteFile(p.storePath, data, 0o644)
+}

--- a/daemon/internal/state/state.go
+++ b/daemon/internal/state/state.go
@@ -402,6 +402,12 @@ func (m *Manager) Unsubscribe(ch chan struct{}) {
 	}
 }
 
+// NotifySubscribers signals all TUI subscribers that state changed.
+// Used by external packages (PR poller) to trigger TUI updates.
+func (m *Manager) NotifySubscribers() {
+	m.notifySubscribers()
+}
+
 func (m *Manager) notifySubscribers() {
 	m.subMu.Lock()
 	defer m.subMu.Unlock()

--- a/daemon/main.go
+++ b/daemon/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/pchaganti/claude-session-manager/daemon/internal/ghostty"
 	"github.com/pchaganti/claude-session-manager/daemon/internal/hookserver"
 	"github.com/pchaganti/claude-session-manager/daemon/internal/notify"
+	"github.com/pchaganti/claude-session-manager/daemon/internal/pr"
 	"github.com/pchaganti/claude-session-manager/daemon/internal/scanner"
 	"github.com/pchaganti/claude-session-manager/daemon/internal/state"
 )
@@ -64,8 +65,17 @@ func runDaemon() {
 	defer httpHookSrv.Close()
 	go httpHookSrv.Serve()
 
+	// Start PR poller.
+	home, _ := os.UserHomeDir()
+	prStorePath := filepath.Join(home, ".csm", "prs.json")
+	prPoller := pr.NewPoller(prStorePath, func() {
+		st.NotifySubscribers()
+	})
+	stopPR := make(chan struct{})
+	go pr.RunLoop(prPoller, 30*time.Second, stopPR)
+
 	// Start control server.
-	ctlSrv, err := ctlserver.New(ctlserver.DefaultSocket, st)
+	ctlSrv, err := ctlserver.New(ctlserver.DefaultSocket, st, prPoller)
 	if err != nil {
 		log.Fatalf("control server: %v", err)
 	}
@@ -93,6 +103,7 @@ func runDaemon() {
 
 	log.Println("csm-daemon shutting down")
 	close(stopScanner)
+	close(stopPR)
 }
 
 func ghosttyLoop(st *state.Manager, stop <-chan struct{}) {

--- a/tui/internal/client/client.go
+++ b/tui/internal/client/client.go
@@ -48,11 +48,56 @@ type Activity struct {
 	Detail       string    `json:"detail,omitempty"`
 }
 
+// TrackedPR mirrors the daemon's PR model.
+type TrackedPR struct {
+	Owner       string    `json:"owner"`
+	Repo        string    `json:"repo"`
+	Number      int       `json:"number"`
+	Title       string    `json:"title"`
+	HeadBranch  string    `json:"head_branch"`
+	BaseBranch  string    `json:"base_branch"`
+	URL         string    `json:"url"`
+	State       string    `json:"state"`
+	Checks      []PRCheck `json:"checks"`
+	Reviews     []PRReview `json:"reviews"`
+	Mergeable   string    `json:"mergeable"`
+	Additions   int       `json:"additions"`
+	Deletions   int       `json:"deletions"`
+	CommitCount int       `json:"commit_count"`
+	AutoMerge   bool      `json:"auto_merge"`
+	Hammer      bool      `json:"hammer"`
+	HammerCount int       `json:"hammer_count"`
+	CreatedAt   time.Time `json:"created_at"`
+	Timeline    []PREvent `json:"timeline"`
+}
+
+type PRCheck struct {
+	Name       string `json:"name"`
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+	Detail     string `json:"detail"`
+	Duration   string `json:"duration"`
+}
+
+type PRReview struct {
+	Author string `json:"author"`
+	State  string `json:"state"`
+	Body   string `json:"body"`
+	At     string `json:"at"`
+}
+
+type PREvent struct {
+	Time    time.Time `json:"time"`
+	Icon    string    `json:"icon"`
+	Message string    `json:"message"`
+}
+
 // serverEvent is the shape of NDJSON messages from the daemon.
 type serverEvent struct {
-	Event    string    `json:"event,omitempty"`
-	Sessions []Session `json:"sessions,omitempty"`
-	OK       *bool     `json:"ok,omitempty"`
+	Event    string      `json:"event,omitempty"`
+	Sessions []Session   `json:"sessions,omitempty"`
+	PRs      []TrackedPR `json:"prs,omitempty"`
+	OK       *bool       `json:"ok,omitempty"`
 }
 
 // request is the shape of NDJSON messages sent to the daemon.
@@ -74,11 +119,14 @@ func New(socketPath string) *Client {
 	return &Client{socketPath: socketPath}
 }
 
-// Subscribe connects to the daemon, sends a subscribe request, and
-// streams session updates into the returned channel. The channel is
-// closed if the connection drops. The caller should call Subscribe
-// again to reconnect.
-func (c *Client) Subscribe() (<-chan []Session, error) {
+// StateUpdate carries both sessions and PRs from a subscribe event.
+type StateUpdate struct {
+	Sessions []Session
+	PRs      []TrackedPR
+}
+
+// Subscribe connects to the daemon and streams state updates.
+func (c *Client) Subscribe() (<-chan StateUpdate, error) {
 	conn, err := net.Dial("unix", c.socketPath)
 	if err != nil {
 		return nil, err
@@ -88,19 +136,17 @@ func (c *Client) Subscribe() (<-chan []Session, error) {
 	c.conn = conn
 	c.mu.Unlock()
 
-	// Send subscribe request.
 	if err := c.writeRequest(request{Action: "subscribe"}); err != nil {
 		conn.Close()
 		return nil, err
 	}
 
-	ch := make(chan []Session, 16)
+	ch := make(chan StateUpdate, 16)
 	go func() {
 		defer close(ch)
 		defer conn.Close()
 
 		scanner := bufio.NewScanner(conn)
-		// Allow large messages (up to 1MB).
 		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 
 		for scanner.Scan() {
@@ -109,8 +155,8 @@ func (c *Client) Subscribe() (<-chan []Session, error) {
 				log.Printf("client: unmarshal error: %v", err)
 				continue
 			}
-			if ev.Event == "sessions_updated" {
-				ch <- ev.Sessions
+			if ev.Event == "state_updated" || ev.Event == "sessions_updated" {
+				ch <- StateUpdate{Sessions: ev.Sessions, PRs: ev.PRs}
 			}
 		}
 	}()

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -13,8 +13,8 @@ import (
 	"github.com/pchaganti/claude-session-manager/tui/internal/client"
 )
 
-// sessionsMsg carries a session update from the daemon.
-type sessionsMsg []client.Session
+// stateMsg carries a state update (sessions + PRs) from the daemon.
+type stateMsg client.StateUpdate
 
 // connectedMsg signals that the subscription was established.
 type connectedMsg struct{}
@@ -41,7 +41,10 @@ type clearFlashMsg struct{}
 type Model struct {
 	client       *client.Client
 	sessions     []client.Session
+	prs          []client.TrackedPR
 	selectedIdx  int
+	// Total items in strip = len(sessions) + len(prs).
+	// Index 0..len(sessions)-1 = sessions, len(sessions)..end = PRs.
 	selectedSID  string // stable selection tracking by session ID
 	queueVisible bool
 	helpVisible  bool
@@ -104,14 +107,14 @@ func waitForUpdate() tea.Msg {
 		return disconnectedMsg{}
 	}
 
-	sessions, ok := <-ch
+	update, ok := <-ch
 	if !ok {
 		subMu.Lock()
 		subCh = nil
 		subMu.Unlock()
 		return disconnectedMsg{}
 	}
-	return sessionsMsg(sessions)
+	return stateMsg(update)
 }
 
 // reconnectAfter returns a command that waits then triggers reconnect.
@@ -168,9 +171,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, glowTick()
 
-	case sessionsMsg:
-		m.sessions = msg
+	case stateMsg:
+		m.sessions = msg.Sessions
+		m.prs = msg.PRs
 		// Restore selection by session ID to prevent jumping.
+		totalItems := len(m.sessions) + len(m.prs)
 		if m.selectedSID != "" {
 			found := false
 			for i, s := range m.sessions {
@@ -181,15 +186,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			if !found {
-				if m.selectedIdx >= len(m.sessions) {
-					m.selectedIdx = max(0, len(m.sessions)-1)
-				}
-				if m.selectedIdx >= 0 && m.selectedIdx < len(m.sessions) {
-					m.selectedSID = m.sessions[m.selectedIdx].SessionID
+				if m.selectedIdx >= totalItems {
+					m.selectedIdx = max(0, totalItems-1)
 				}
 			}
-		} else if m.selectedIdx >= len(m.sessions) {
-			m.selectedIdx = max(0, len(m.sessions)-1)
+		} else if m.selectedIdx >= totalItems {
+			m.selectedIdx = max(0, totalItems-1)
 		}
 		return m, waitForUpdate
 
@@ -235,7 +237,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case "right", "l":
-		if m.selectedIdx < len(m.sessions)-1 {
+		if m.selectedIdx < m.totalItems()-1 {
 			m.selectedIdx++
 			m.scrollOffset = 0 // reset scroll on session change
 			if m.selectedIdx < len(m.sessions) {
@@ -381,6 +383,26 @@ func (m Model) selected() *client.Session {
 	return nil
 }
 
+// selectedPR returns the currently selected PR, or nil.
+func (m Model) selectedPR() *client.TrackedPR {
+	prIdx := m.selectedIdx - len(m.sessions)
+	if prIdx >= 0 && prIdx < len(m.prs) {
+		pr := m.prs[prIdx]
+		return &pr
+	}
+	return nil
+}
+
+// isSessionSelected returns true if a session (not PR) is selected.
+func (m Model) isSessionSelected() bool {
+	return m.selectedIdx < len(m.sessions)
+}
+
+// totalItems returns the total number of items in the strip.
+func (m Model) totalItems() int {
+	return len(m.sessions) + len(m.prs)
+}
+
 // View renders the entire TUI.
 func (m Model) View() string {
 	if m.width == 0 || m.height == 0 {
@@ -396,16 +418,23 @@ func (m Model) View() string {
 	}
 
 	// Render bottom sections first to calculate remaining height.
-	strip := renderStrip(m.sessions, m.selectedIdx, w, m.glowPos)
+	strip := renderUnifiedStrip(m.sessions, m.prs, m.selectedIdx, w, m.glowPos)
 	stripHeight := lipgloss.Height(strip)
 
+	isSession := m.isSessionSelected()
 	hints := renderHints(m.queueVisible, hasPending, w)
 	hintsHeight := lipgloss.Height(hints)
 
 	bottomHeight := stripHeight + hintsHeight
 
 	// Status bar.
-	statusLine := renderStatusBar(m.connected, m.sessions, m.flash, m.flashStyle, w)
+	failingPRs := 0
+	for _, p := range m.prs {
+		if p.State == "checks_failing" {
+			failingPRs++
+		}
+	}
+	statusLine := renderStatusBar(m.connected, m.sessions, m.prs, failingPRs, m.flash, m.flashStyle, w)
 	statusHeight := lipgloss.Height(statusLine)
 
 	remainingHeight := m.height - bottomHeight - statusHeight
@@ -414,8 +443,14 @@ func (m Model) View() string {
 	mainContent := ""
 	if m.queueVisible && hasPending {
 		mainContent = renderQueue(m.sessions, w, remainingHeight)
-	} else if sel := m.selected(); sel != nil {
-		mainContent = renderZoom(*sel, w, remainingHeight, m.scrollOffset)
+	} else if isSession {
+		if sel := m.selected(); sel != nil {
+			mainContent = renderZoom(*sel, w, remainingHeight, m.scrollOffset)
+		} else {
+			mainContent = renderEmptyState(w, remainingHeight)
+		}
+	} else if selPR := m.selectedPR(); selPR != nil {
+		mainContent = renderPRZoom(*selPR, w, remainingHeight, m.scrollOffset)
 	} else {
 		mainContent = renderEmptyState(w, remainingHeight)
 	}
@@ -436,11 +471,11 @@ func (m Model) View() string {
 }
 
 // renderStatusBar renders the top status bar with branding, connection info, and flash.
-func renderStatusBar(connected bool, sessions []client.Session, flash string, flashStyle lipgloss.Style, width int) string {
+func renderStatusBar(connected bool, sessions []client.Session, prs []client.TrackedPR, failingPRs int, flash string, flashStyle lipgloss.Style, width int) string {
 	logo := lipgloss.NewStyle().
 		Bold(true).
 		Foreground(colorAccent).
-		Render("\u2588\u2588 CSM")
+		Render("\u2588\u2588 CCC")
 
 	var connStatus string
 	if !connected {
@@ -457,6 +492,13 @@ func renderStatusBar(connected bool, sessions []client.Session, flash string, fl
 		Foreground(colorDimFg).
 		Render(pluralize(len(sessions), "session", "sessions"))
 
+	prCount := ""
+	if len(prs) > 0 {
+		prCount = "  " + lipgloss.NewStyle().
+			Foreground(colorDimFg).
+			Render(pluralize(len(prs), "PR", "PRs"))
+	}
+
 	pendingStr := ""
 	pending := countPending(sessions)
 	if pending > 0 {
@@ -464,6 +506,14 @@ func renderStatusBar(connected bool, sessions []client.Session, flash string, fl
 			Foreground(colorOrange).
 			Bold(true).
 			Render(fmt.Sprintf("  \u26a1 %d pending", pending))
+	}
+
+	failingStr := ""
+	if failingPRs > 0 {
+		failingStr = lipgloss.NewStyle().
+			Foreground(colorDestructive).
+			Bold(true).
+			Render(fmt.Sprintf("  \u2717 %d failing", failingPRs))
 	}
 
 	runningStr := ""
@@ -479,7 +529,7 @@ func renderStatusBar(connected bool, sessions []client.Session, flash string, fl
 			Render(fmt.Sprintf("  \u25b6 %d running", running))
 	}
 
-	left := logo + "  " + connStatus + "  " + sessionCount + runningStr + pendingStr
+	left := logo + "  " + connStatus + "  " + sessionCount + prCount + runningStr + pendingStr + failingStr
 
 	// Flash message (action feedback).
 	if flash != "" {
@@ -559,5 +609,5 @@ func itoa(n int) string {
 
 var (
 	subMu sync.Mutex
-	subCh <-chan []client.Session
+	subCh <-chan client.StateUpdate
 )

--- a/tui/internal/tui/pr_zoom.go
+++ b/tui/internal/tui/pr_zoom.go
@@ -1,0 +1,260 @@
+package tui
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	"github.com/pchaganti/claude-session-manager/tui/internal/client"
+)
+
+// renderPRZoom renders the PR detail panel.
+func renderPRZoom(pr client.TrackedPR, width, height int, scrollOffset int) string {
+	if width < 10 || height < 4 {
+		return ""
+	}
+
+	innerWidth := width - 4
+
+	// ── Fixed header (2 lines) ──
+	var headerLines []string
+
+	// Line 1: owner/repo#number  title → base   state
+	prRef := fmt.Sprintf("%s/%s#%d", pr.Owner, pr.Repo, pr.Number)
+	refStyle := lipgloss.NewStyle().Foreground(colorAccent).Underline(true)
+	stateStyle := lipgloss.NewStyle().
+		Foreground(lipgloss.ANSIColor(0)).
+		Background(prStateColor(pr.State)).
+		Bold(true).
+		Padding(0, 1)
+
+	line1 := "  " + refStyle.Render(prRef) + "  " +
+		styleZoomHeader.Render(pr.Title) + " " +
+		stateStyle.Render(prStateLabel(pr.State))
+	if pr.Hammer {
+		line1 += " " + lipgloss.NewStyle().Foreground(colorOrange).Bold(true).Render("🔨")
+	}
+	headerLines = append(headerLines, line1)
+
+	// Line 2: branch → base  +42 -12  3 commits  mergeable
+	var infoParts []string
+	infoParts = append(infoParts, pr.HeadBranch+" → "+pr.BaseBranch)
+	infoParts = append(infoParts, fmt.Sprintf("+%d -%d", pr.Additions, pr.Deletions))
+	infoParts = append(infoParts, fmt.Sprintf("%d commits", pr.CommitCount))
+	if pr.Mergeable == "MERGEABLE" {
+		infoParts = append(infoParts, "mergeable")
+	} else if pr.Mergeable == "CONFLICTING" {
+		infoParts = append(infoParts, lipgloss.NewStyle().Foreground(colorDestructive).Render("conflicts"))
+	}
+	if pr.AutoMerge {
+		infoParts = append(infoParts, "automerge")
+	}
+	headerLines = append(headerLines, "  "+lipgloss.NewStyle().Foreground(colorDimFg).
+		Render(strings.Join(infoParts, "  ")))
+
+	headerHeight := len(headerLines)
+	bodyHeight := height - headerHeight
+
+	// ── Scrollable body ──
+	var bodyLines []string
+
+	sep := lipgloss.NewStyle().Foreground(colorBorder).
+		Render(strings.Repeat("─", min(innerWidth, 60)))
+
+	// Checks section.
+	if len(pr.Checks) > 0 {
+		passing, total := 0, len(pr.Checks)
+		for _, c := range pr.Checks {
+			if c.Conclusion == "SUCCESS" || c.Conclusion == "NEUTRAL" {
+				passing++
+			}
+		}
+		bodyLines = append(bodyLines, styleSectionLabel.Render(
+			fmt.Sprintf("── Checks (%d/%d passing)", passing, total)))
+
+		for _, c := range pr.Checks {
+			icon := checkIcon(c)
+			name := lipgloss.NewStyle().Foreground(colorFg).Render(c.Name)
+			status := checkStatusText(c)
+			dur := ""
+			if c.Duration != "" {
+				dur = "  " + lipgloss.NewStyle().Foreground(colorDimFg).Render(c.Duration)
+			}
+			detail := ""
+			if c.Detail != "" {
+				detail = "  " + lipgloss.NewStyle().Foreground(colorDimFg).Italic(true).
+					Render(truncateMiddle(c.Detail, innerWidth-40))
+			}
+			bodyLines = append(bodyLines, fmt.Sprintf("  %s %s  %s%s%s", icon, name, status, dur, detail))
+		}
+	}
+
+	// Reviews section.
+	if len(pr.Reviews) > 0 {
+		bodyLines = append(bodyLines, sep)
+		bodyLines = append(bodyLines, styleSectionLabel.Render("── Reviews"))
+		for _, r := range pr.Reviews {
+			icon := reviewIcon(r.State)
+			author := lipgloss.NewStyle().Foreground(colorFg).Render("@" + r.Author)
+			state := lipgloss.NewStyle().Foreground(colorDimFg).Render(strings.ToLower(r.State))
+			body := ""
+			if r.Body != "" {
+				bodyTrunc := r.Body
+				if len(bodyTrunc) > 50 {
+					bodyTrunc = bodyTrunc[:50] + "…"
+				}
+				body = "  " + lipgloss.NewStyle().Foreground(colorDimFg).Italic(true).
+					Render("\""+bodyTrunc+"\"")
+			}
+			at := ""
+			if r.At != "" {
+				at = "  " + lipgloss.NewStyle().Foreground(colorSubtle).Render(r.At)
+			}
+			bodyLines = append(bodyLines, fmt.Sprintf("  %s %s  %s%s%s", icon, author, state, body, at))
+		}
+	}
+
+	// Timeline section.
+	if len(pr.Timeline) > 0 {
+		bodyLines = append(bodyLines, sep)
+		bodyLines = append(bodyLines, styleSectionLabel.Render("── Timeline"))
+		for _, ev := range pr.Timeline {
+			ts := lipgloss.NewStyle().Foreground(colorSubtle).Render(ev.Time.Format("15:04"))
+			icon := ev.Icon
+			msg := lipgloss.NewStyle().Foreground(colorDimFg).Render(ev.Message)
+			bodyLines = append(bodyLines, fmt.Sprintf("  %s  %s  %s", ts, icon, msg))
+		}
+	}
+
+	// URL.
+	bodyLines = append(bodyLines, sep)
+	bodyLines = append(bodyLines, "  "+lipgloss.NewStyle().Foreground(colorAccent).Underline(true).
+		Render(pr.URL))
+
+	// Scroll + clip.
+	maxScroll := len(bodyLines) - bodyHeight
+	if maxScroll < 0 {
+		maxScroll = 0
+	}
+	if scrollOffset > maxScroll {
+		scrollOffset = maxScroll
+	}
+
+	visibleBody := bodyLines
+	if scrollOffset > 0 && scrollOffset < len(visibleBody) {
+		visibleBody = visibleBody[scrollOffset:]
+	}
+	if len(visibleBody) > bodyHeight {
+		visibleBody = visibleBody[:bodyHeight]
+	}
+
+	// Scroll indicator.
+	if maxScroll > 0 {
+		scrollInfo := lipgloss.NewStyle().Foreground(colorDimFg)
+		if scrollOffset > 0 {
+			headerLines[len(headerLines)-1] += scrollInfo.Render(
+				fmt.Sprintf(" ↑↓ %d%%", scrollOffset*100/maxScroll))
+		} else {
+			headerLines[len(headerLines)-1] += scrollInfo.Render(" ↓ scroll")
+		}
+	}
+
+	// Assemble.
+	all := append(headerLines, visibleBody...)
+	if len(all) > height {
+		all = all[:height]
+	}
+	for len(all) < height {
+		all = append(all, "")
+	}
+
+	return lipgloss.NewStyle().Width(width).Render(strings.Join(all, "\n"))
+}
+
+func prStateColor(state string) lipgloss.TerminalColor {
+	switch state {
+	case "checks_failing":
+		return colorDestructive
+	case "checks_running":
+		return colorWaiting
+	case "checks_passing":
+		return colorRunning
+	case "approved":
+		return colorRunning
+	case "merged":
+		return lipgloss.ANSIColor(5) // magenta
+	default:
+		return colorDimFg
+	}
+}
+
+func prStateLabel(state string) string {
+	switch state {
+	case "checks_failing":
+		return "FAILING"
+	case "checks_running":
+		return "RUNNING"
+	case "checks_passing":
+		return "PASSING"
+	case "approved":
+		return "APPROVED"
+	case "merged":
+		return "MERGED"
+	case "closed":
+		return "CLOSED"
+	default:
+		return strings.ToUpper(state)
+	}
+}
+
+func checkIcon(c client.PRCheck) string {
+	switch c.Conclusion {
+	case "SUCCESS":
+		return styleSafe.Render("✓")
+	case "FAILURE":
+		return styleDestructive.Render("✗")
+	case "NEUTRAL":
+		return lipgloss.NewStyle().Foreground(colorDimFg).Render("○")
+	default:
+		if c.Status == "IN_PROGRESS" || c.Status == "QUEUED" {
+			return lipgloss.NewStyle().Foreground(colorWaiting).Render("⏳")
+		}
+		return "•"
+	}
+}
+
+func checkStatusText(c client.PRCheck) string {
+	switch c.Conclusion {
+	case "SUCCESS":
+		return styleSafe.Render("passed")
+	case "FAILURE":
+		return styleDestructive.Render("failed")
+	case "NEUTRAL":
+		return lipgloss.NewStyle().Foreground(colorDimFg).Render("neutral")
+	default:
+		if c.Status == "IN_PROGRESS" {
+			return lipgloss.NewStyle().Foreground(colorWaiting).Render("running")
+		}
+		if c.Status == "QUEUED" {
+			return lipgloss.NewStyle().Foreground(colorDimFg).Render("queued")
+		}
+		return c.Status
+	}
+}
+
+func reviewIcon(state string) string {
+	switch state {
+	case "APPROVED":
+		return styleSafe.Render("✓")
+	case "CHANGES_REQUESTED":
+		return styleDestructive.Render("✗")
+	case "COMMENTED":
+		return lipgloss.NewStyle().Foreground(colorAccent).Render("💬")
+	default:
+		return lipgloss.NewStyle().Foreground(colorWaiting).Render("⏳")
+	}
+}
+
+// Suppress unused import warning.
+var _ = time.Now

--- a/tui/internal/tui/strip.go
+++ b/tui/internal/tui/strip.go
@@ -1,30 +1,86 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/pchaganti/claude-session-manager/tui/internal/client"
 )
 
-// renderStrip renders the horizontal session pill strip at the bottom.
+// renderStrip renders the horizontal session pill strip at the bottom (sessions only).
 func renderStrip(sessions []client.Session, selectedIdx int, width int, glowPos int) string {
-	if len(sessions) == 0 {
-		emptyStyle := lipgloss.NewStyle().
-			Foreground(colorDimFg).
-			Italic(true)
+	return renderUnifiedStrip(sessions, nil, selectedIdx, width, glowPos)
+}
+
+// renderUnifiedStrip renders sessions + PRs in one strip with a separator.
+func renderUnifiedStrip(sessions []client.Session, prs []client.TrackedPR, selectedIdx int, width int, glowPos int) string {
+	if len(sessions) == 0 && len(prs) == 0 {
+		emptyStyle := lipgloss.NewStyle().Foreground(colorDimFg).Italic(true)
 		return styleStripBar.Width(width).Render(
-			emptyStyle.Render("  No active sessions"))
+			emptyStyle.Render("  No active sessions or PRs"))
 	}
 
 	var pills []string
+
+	// Session pills.
 	for i, s := range sessions {
 		pills = append(pills, renderPill(s, i == selectedIdx, glowPos))
 	}
 
-	row := lipgloss.JoinHorizontal(lipgloss.Center, interleave(pills, " ")...)
+	// Separator between sessions and PRs.
+	if len(sessions) > 0 && len(prs) > 0 {
+		pills = append(pills, lipgloss.NewStyle().Foreground(colorBorder).Render("│"))
+	}
 
+	// PR pills.
+	for i, p := range prs {
+		prIdx := len(sessions) + i
+		pills = append(pills, renderPRPill(p, prIdx == selectedIdx))
+	}
+
+	row := lipgloss.JoinHorizontal(lipgloss.Center, interleave(pills, " ")...)
 	return styleStripBar.Width(width).Render(row)
+}
+
+// renderPRPill renders a single PR pill in the strip.
+func renderPRPill(p client.TrackedPR, selected bool) string {
+	icon := prPillIcon(p.State)
+	label := fmt.Sprintf("%s #%d %s", icon, p.Number, truncateMiddle(p.Title, 15))
+
+	sc := prStateColor(p.State)
+
+	style := lipgloss.NewStyle().
+		Padding(0, 1).
+		Foreground(sc)
+
+	if selected {
+		style = style.
+			Bold(true).
+			Foreground(lipgloss.ANSIColor(15)).
+			Background(sc).
+			Border(lipgloss.RoundedBorder()).
+			BorderForeground(sc)
+	}
+
+	return style.Render(label)
+}
+
+func prPillIcon(state string) string {
+	switch state {
+	case "checks_failing":
+		return "✗"
+	case "checks_running":
+		return "⏳"
+	case "checks_passing":
+		return "✓"
+	case "approved":
+		return "✅"
+	case "merged":
+		return "🚀"
+	default:
+		return "•"
+	}
 }
 
 // interleave inserts a separator between each element.


### PR DESCRIPTION
## Summary

First step toward Claude Control Center — sessions + PR lifecycle in one TUI.

### Daemon
- New `pr/` package: `TrackedPR` model + `gh` CLI poller (every 30s)
- Zero tokens — pure `gh pr view --json` for CI checks, reviews, state
- PRs persisted to `~/.csm/prs.json`
- Control protocol: `add_pr` (URL), `remove_pr` (key), included in subscribe events

### TUI
- **Unified strip**: sessions `│` PRs — navigate through both with ←→
- **PR pills**: ✗ failing (red), ✓ passing (green), ⏳ running (yellow), 🚀 merged
- **PR zoom panel**: checks detail (pass/fail/running), reviews, timeline, clickable URL
- **Status bar**: `██ CCC` with session + PR counts + failing badge

### Next steps (not in this PR)
- `+`/`-` keys for add/remove PRs
- Auto-detect PR creation from PostToolUse hook
- Fix-CI agent spawning
- Auto-merge

## Test plan
- [x] All existing tests pass (91)
- [x] Daemon builds and installs
- [x] TUI builds
- [ ] Manual: add PR via control socket, verify it appears in TUI