### PR TITLE
Paste support, Enter opens PR, fix issues #15 #16 #17, flexible CLI detection

### DIFF
--- a/daemon/internal/hookserver/handler.go
+++ b/daemon/internal/hookserver/handler.go
@@ -164,6 +164,8 @@ func (h *Handler) handlePreToolUse(req hookRequest) hookResponse {
 		}
 	case <-time.After(60 * time.Second):
 		// Timeout — passthrough to CC's default permission logic.
+		// Clean up the pending entry so it doesn't go stale.
+		h.state.ClearPending(req.SessionID)
 		log.Printf("hook: timeout waiting for decision on %s (60s)", req.ToolName)
 		return hookResponse{}
 	}

--- a/daemon/internal/scanner/scanner.go
+++ b/daemon/internal/scanner/scanner.go
@@ -110,17 +110,19 @@ type procInfo struct {
 // isClaudeCLI returns true if cmd looks like the actual `claude` CLI binary,
 // excluding Claude.app, csm-daemon, and claude-session-manager.
 func isClaudeCLI(cmd string) bool {
-	base := filepath.Base(cmd)
-	if base != "claude" {
-		return false
-	}
+	// Exclude known non-CLI binaries first.
 	if strings.Contains(cmd, "Claude.app") {
 		return false
 	}
 	if strings.Contains(cmd, "csm-daemon") || strings.Contains(cmd, "claude-session-manager") {
 		return false
 	}
-	return true
+	// Match any path ending in "claude" as the binary name.
+	// filepath.Base handles all path formats:
+	//   "claude" → "claude"
+	//   "/usr/local/bin/claude" → "claude"
+	//   "/Users/x/.local/share/claude/versions/2.1.76/claude" → "claude"
+	return filepath.Base(cmd) == "claude"
 }
 
 func findClaudeProcesses() []procInfo {

--- a/daemon/internal/state/state.go
+++ b/daemon/internal/state/state.go
@@ -248,6 +248,23 @@ func (m *Manager) ResolvePending(sid string, decision model.ApprovalDecision) bo
 	return true
 }
 
+// ClearPending removes the pending approval and clears PendingTools on a session.
+// Called when a hook times out to prevent stale pending state.
+func (m *Manager) ClearPending(sid string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if pa, ok := m.pending[sid]; ok {
+		close(pa.ResponseCh)
+		delete(m.pending, sid)
+	}
+	if s, ok := m.sessions[sid]; ok {
+		s.PendingTools = nil
+		s.HasDestructive = false
+	}
+	m.notifySubscribers()
+}
+
 // ShouldAutoApprove checks if autopilot should auto-approve a tool for this session.
 // Returns: approve immediately, or "grace" for YOLO destructive (delayed approve).
 func (m *Manager) ShouldAutoApprove(sid string, safety model.ToolSafety) (bool, bool) {

--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -248,9 +248,26 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 				m.inputBuffer = m.inputBuffer[:len(m.inputBuffer)-1]
 			}
 			return m, nil
+		case "ctrl+u":
+			// Clear entire input.
+			m.inputBuffer = ""
+			return m, nil
+		case "ctrl+w":
+			// Delete last word.
+			buf := strings.TrimRight(m.inputBuffer, " ")
+			if idx := strings.LastIndexByte(buf, ' '); idx >= 0 {
+				m.inputBuffer = buf[:idx+1]
+			} else {
+				m.inputBuffer = ""
+			}
+			return m, nil
 		default:
-			if len(msg.String()) == 1 {
-				m.inputBuffer += msg.String()
+			// Accept printable characters and pasted multi-char strings.
+			s := msg.String()
+			for _, r := range s {
+				if r >= 32 && r != 127 { // printable, non-control
+					m.inputBuffer += string(r)
+				}
 			}
 			return m, nil
 		}
@@ -373,10 +390,16 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "enter", "return":
-		if sel := m.selected(); sel != nil && sel.GhosttyTabIndex > 0 {
+		// Session: focus Ghostty tab. PR: open in browser.
+		if pr := m.selectedPR(); pr != nil {
+			url := pr.URL
+			return m, func() tea.Msg {
+				err := exec.Command("open", url).Run()
+				return actionResultMsg{action: "opened PR", err: err}
+			}
+		} else if sel := m.selected(); sel != nil && sel.GhosttyTabIndex > 0 {
 			tabIdx := sel.GhosttyTabIndex
 			return m, func() tea.Msg {
-				// Switch by tab index — stable unlike names with animated spinners.
 				script := fmt.Sprintf(`tell application "System Events" to tell process "Ghostty"
     set tabGroup to tab group 1 of window 1
     set allButtons to every radio button of tabGroup
@@ -385,10 +408,7 @@ func (m Model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
     end if
 end tell`, tabIdx, tabIdx)
 				err := exec.Command("osascript", "-e", script).Run()
-				if err != nil {
-					return actionResultMsg{action: "focus", err: err}
-				}
-				return actionResultMsg{action: "focus"}
+				return actionResultMsg{action: "focus", err: err}
 			}
 		}
 

--- a/tui/internal/tui/pill.go
+++ b/tui/internal/tui/pill.go
@@ -65,12 +65,13 @@ func pillName(s client.Session) string {
 	if tab != "" && !looksLikeCommand(tab) {
 		return tab
 	}
-	// Auto slug is still better than directory name.
+	// Project name (directory) before auto-generated slug.
+	if s.ProjectName != "" && s.ProjectName != "/" {
+		return s.ProjectName
+	}
+	// Auto slug as last resort before session ID.
 	if s.Slug != "" {
 		return s.Slug
-	}
-	if s.ProjectName != "" {
-		return s.ProjectName
 	}
 	if len(s.SessionID) >= 8 {
 		return s.SessionID[:8]
@@ -89,14 +90,15 @@ func renderPill(s client.Session, selected bool, glowPos int) string {
 
 	label := icon + " " + name
 
-	// Pending badge.
+	// Pending badge — rendered separately to avoid nested ANSI conflicts.
+	badge := ""
 	if n := len(s.PendingTools); n > 0 {
-		badgeStyle := lipgloss.NewStyle().
+		badge = " " + lipgloss.NewStyle().
 			Foreground(lipgloss.ANSIColor(15)).
 			Background(colorBadgeBg).
 			Bold(true).
-			Padding(0, 1)
-		label += " " + badgeStyle.Render(fmt.Sprintf("%d", n))
+			Padding(0, 1).
+			Render(fmt.Sprintf("%d", n))
 	}
 
 	style := lipgloss.NewStyle().
@@ -112,5 +114,5 @@ func renderPill(s client.Session, selected bool, glowPos int) string {
 			Underline(true)
 	}
 
-	return style.Render(label)
+	return style.Render(label) + badge
 }


### PR DESCRIPTION
## Changes

### Input mode (+)
- Accept all printable characters (handles Ctrl+V paste)
- Ctrl+U: clear entire input
- Ctrl+W: delete last word
- Filter control characters from pasted text

### Enter key
- PR selected: opens PR in browser
- Session selected: focuses Ghostty tab (existing)

### Fixes #15 — Pills show animal names instead of project name
`pillName()` now prefers project directory name over auto-generated CC slugs like `purring-mossy-salamander`.

### Fixes #16 — ANSI escape codes leak in pending badge
Pending count badge rendered separately from pill style to avoid nested ANSI conflicts.

### Fixes #17 — Stale pending approvals never cleared
Added `ClearPending()` to state manager. Called on hook timeout (60s) to remove stale `PendingTools` from session.

### Flexible CLI detection
`isClaudeCLI` documented to handle all install paths via `filepath.Base` — works for bare `claude`, `/usr/local/bin/claude`, `~/.local/share/claude/versions/X/claude`, etc.

## Test plan
- [x] All tests pass
- [x] Both binaries build