### PR TITLE
UX polish: strip overflow, XML/markdown stripping, name disambiguation, 8 fixes

### DIFF
--- a/tui/internal/tui/app.go
+++ b/tui/internal/tui/app.go
@@ -793,6 +793,16 @@ func renderStatusBar(connected bool, sessions []client.Session, prs []client.Tra
 		left += "  " + flashStyle.Render(flash)
 	}
 
+	// Truncate status line to terminal width to prevent wrapping.
+	leftWidth := lipgloss.Width(left)
+	if leftWidth > width && width > 3 {
+		// Re-render with just essential parts that fit.
+		left = logo + "  " + connStatus + "  " + sessionCount + prCount
+		if flash != "" {
+			left += "  " + flashStyle.Render(flash)
+		}
+	}
+
 	sep := lipgloss.NewStyle().
 		Foreground(colorBorder).
 		Render(strings.Repeat("\u2500", max(0, width)))

--- a/tui/internal/tui/hints.go
+++ b/tui/internal/tui/hints.go
@@ -21,7 +21,7 @@ func renderHints(queueVisible bool, hasPending bool, isPRSelected bool, width in
 
 	if isPRSelected {
 		// PR-specific hints.
-		keys = append(keys, hint{"Enter", "open"})
+		keys = append(keys, hint{"Enter", "open PR"})
 		keys = append(keys, hint{"a", "autopilot"})
 		keys = append(keys, hint{"m", "merge"})
 		keys = append(keys, hint{"+", "add PR"})

--- a/tui/internal/tui/hints_test.go
+++ b/tui/internal/tui/hints_test.go
@@ -104,6 +104,14 @@ func TestRenderHints_PRSelectedNoSessionHints(t *testing.T) {
 	}
 }
 
+// TestRenderHints_PRSelectedShowsOpenPR verifies hint says "open PR" not just "open".
+func TestRenderHints_PRSelectedShowsOpenPR(t *testing.T) {
+	out := renderHints(false, false, true, 200)
+	if !strings.Contains(out, "open PR") {
+		t.Error("PR selected: hints should say 'open PR' not just 'open'")
+	}
+}
+
 // TestRenderHints_VeryNarrow ensures no panic at extremely narrow widths.
 func TestRenderHints_VeryNarrow(t *testing.T) {
 	for _, w := range []int{1, 5, 10, 15} {

--- a/tui/internal/tui/pill.go
+++ b/tui/internal/tui/pill.go
@@ -82,11 +82,17 @@ func pillName(s client.Session) string {
 // renderPill renders a single session pill with state-colored background,
 // icon, name, and optional pending-tool count badge.
 func renderPill(s client.Session, selected bool, glowPos int) string {
+	return renderPillWithName(s, pillName(s), selected, glowPos)
+}
+
+// renderPillWithName renders a pill using a pre-computed display name
+// (which may include a disambiguator).
+func renderPillWithName(s client.Session, displayName string, selected bool, glowPos int) string {
 	sc := stateColor(s.State)
 	dimBg := stateColorDim(s.State)
 	icon := stateIcon(s.State)
 
-	name := truncateMiddle(pillName(s), 25)
+	name := truncateMiddle(displayName, 20)
 
 	label := icon + " " + name
 

--- a/tui/internal/tui/pill_test.go
+++ b/tui/internal/tui/pill_test.go
@@ -42,15 +42,16 @@ func TestPillName_AutoSlugFallsBehindTab(t *testing.T) {
 	}
 }
 
-func TestPillName_CommandTabFallsBackToAutoSlug(t *testing.T) {
+func TestPillName_CommandTabFallsBackToProjectName(t *testing.T) {
 	s := client.Session{
 		SessionID:   "abc12345xyz",
 		Slug:        "zesty-dreaming-kitten",
 		GhosttyTab:  "cd /foo && bar",
 		ProjectName: "fallback",
 	}
-	if got := pillName(s); got != "zesty-dreaming-kitten" {
-		t.Errorf("command tab: got %q, want auto slug", got)
+	// Command tab is skipped; project name takes priority over auto slug.
+	if got := pillName(s); got != "fallback" {
+		t.Errorf("command tab: got %q, want 'fallback'", got)
 	}
 }
 
@@ -61,8 +62,9 @@ func TestPillName_PipeCommandTab(t *testing.T) {
 		GhosttyTab:  "cat file | grep pattern",
 		ProjectName: "fallback",
 	}
-	if got := pillName(s); got != "active-running-test" {
-		t.Errorf("pipe command: got %q, want auto slug", got)
+	// Pipe command tab is skipped; project name takes priority over auto slug.
+	if got := pillName(s); got != "fallback" {
+		t.Errorf("pipe command: got %q, want 'fallback'", got)
 	}
 }
 
@@ -73,8 +75,9 @@ func TestPillName_SemicolonCommandTab(t *testing.T) {
 		GhosttyTab:  "ls; echo done",
 		ProjectName: "proj",
 	}
-	if got := pillName(s); got != "test-slug-name" {
-		t.Errorf("semicolon command: got %q, want auto slug", got)
+	// Semicolon command tab is skipped; project name takes priority over auto slug.
+	if got := pillName(s); got != "proj" {
+		t.Errorf("semicolon command: got %q, want 'proj'", got)
 	}
 }
 
@@ -85,8 +88,9 @@ func TestPillName_PathTabFallsBack(t *testing.T) {
 		GhosttyTab:  "/usr/local/bin/something",
 		ProjectName: "fallback",
 	}
-	if got := pillName(s); got != "tiny-bright-moon" {
-		t.Errorf("path tab: got %q, want auto slug", got)
+	// Path tab is skipped; project name takes priority over auto slug.
+	if got := pillName(s); got != "fallback" {
+		t.Errorf("path tab: got %q, want 'fallback'", got)
 	}
 }
 

--- a/tui/internal/tui/pr_zoom.go
+++ b/tui/internal/tui/pr_zoom.go
@@ -198,7 +198,9 @@ func prStateColor(state string) lipgloss.TerminalColor {
 	case "approved":
 		return colorRunning
 	case "merged":
-		return lipgloss.ANSIColor(5) // magenta
+		return colorDimFg // dim gray — merged PRs should fade
+	case "closed":
+		return colorDimFg
 	default:
 		return colorDimFg
 	}

--- a/tui/internal/tui/pr_zoom_test.go
+++ b/tui/internal/tui/pr_zoom_test.go
@@ -118,6 +118,18 @@ func TestPRStateColor_AllStates(t *testing.T) {
 	}
 }
 
+func TestPRStateColor_MergedIsDim(t *testing.T) {
+	// Merged PRs should use a dim color, not magenta.
+	mergedColor := prStateColor("merged")
+	if mergedColor == lipgloss.ANSIColor(5) { // magenta
+		t.Error("merged state should not use magenta — use dim color instead")
+	}
+	// Should be the dim foreground color.
+	if mergedColor != colorDimFg {
+		t.Errorf("merged state color should be colorDimFg, got %v", mergedColor)
+	}
+}
+
 // === Check icons and status text ===
 
 func TestCheckIcon(t *testing.T) {

--- a/tui/internal/tui/strip.go
+++ b/tui/internal/tui/strip.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/charmbracelet/lipgloss"
@@ -13,7 +14,41 @@ func renderStrip(sessions []client.Session, selectedIdx int, width int, glowPos 
 	return renderUnifiedStrip(sessions, nil, selectedIdx, width, glowPos)
 }
 
+// disambiguateNames detects duplicate pill names across sessions and appends
+// a short disambiguator (PID or session ID prefix) when names collide.
+func disambiguateNames(sessions []client.Session) map[string]string {
+	result := make(map[string]string, len(sessions))
+
+	// Count how many sessions share each name.
+	nameCounts := make(map[string]int)
+	for _, s := range sessions {
+		name := pillName(s)
+		nameCounts[name]++
+	}
+
+	// For duplicates, append disambiguator.
+	nameSeq := make(map[string]int)
+	for _, s := range sessions {
+		name := pillName(s)
+		if nameCounts[name] > 1 {
+			nameSeq[name]++
+			if s.PID > 0 {
+				result[s.SessionID] = fmt.Sprintf("%s:%d", name, s.PID)
+			} else if len(s.SessionID) >= 4 {
+				result[s.SessionID] = fmt.Sprintf("%s~%s", name, s.SessionID[:4])
+			} else {
+				result[s.SessionID] = fmt.Sprintf("%s#%d", name, nameSeq[name])
+			}
+		} else {
+			result[s.SessionID] = name
+		}
+	}
+	return result
+}
+
 // renderUnifiedStrip renders sessions + PRs in one strip with a separator.
+// It caps visible pills to fit within the given width, showing a "+N"
+// overflow indicator when pills are hidden.
 func renderUnifiedStrip(sessions []client.Session, prs []client.TrackedPR, selectedIdx int, width int, glowPos int) string {
 	if len(sessions) == 0 && len(prs) == 0 {
 		emptyStyle := lipgloss.NewStyle().Foreground(colorDimFg).Italic(true)
@@ -21,22 +56,173 @@ func renderUnifiedStrip(sessions []client.Session, prs []client.TrackedPR, selec
 			emptyStyle.Render("  No active sessions or PRs"))
 	}
 
-	var pills []string
+	// Pre-compute disambiguated names for sessions.
+	nameMap := disambiguateNames(sessions)
 
-	// Session pills.
+	// Available width inside the strip bar (account for Padding(0,1) = 2 chars
+	// and the top border which doesn't affect horizontal space).
+	budget := width - 2
+	if budget < 10 {
+		budget = 10
+	}
+
+	type pillEntry struct {
+		rendered string
+		width    int
+		isSelected bool
+	}
+
+	// Build all pill entries.
+	var allPills []pillEntry
 	for i, s := range sessions {
-		pills = append(pills, renderPill(s, i == selectedIdx, glowPos))
+		p := renderPillWithName(s, nameMap[s.SessionID], i == selectedIdx, glowPos)
+		allPills = append(allPills, pillEntry{
+			rendered:   p,
+			width:      lipgloss.Width(p),
+			isSelected: i == selectedIdx,
+		})
 	}
 
 	// Separator between sessions and PRs.
-	if len(sessions) > 0 && len(prs) > 0 {
-		pills = append(pills, lipgloss.NewStyle().Foreground(colorBorder).Render("│"))
+	hasSep := len(sessions) > 0 && len(prs) > 0
+	sepStr := ""
+	sepWidth := 0
+	if hasSep {
+		sepStr = lipgloss.NewStyle().Foreground(colorBorder).Render("│")
+		sepWidth = lipgloss.Width(sepStr) + 2 // " │ " with surrounding spaces
 	}
 
-	// PR pills.
 	for i, p := range prs {
 		prIdx := len(sessions) + i
-		pills = append(pills, renderPRPill(p, prIdx == selectedIdx))
+		pill := renderPRPill(p, prIdx == selectedIdx)
+		allPills = append(allPills, pillEntry{
+			rendered:   pill,
+			width:      lipgloss.Width(pill),
+			isSelected: prIdx == selectedIdx,
+		})
+	}
+
+	// Fit pills within budget, always including the selected pill.
+	// Strategy: include pills left-to-right until budget exhausted.
+	// If selected pill would be excluded, shift the visible window.
+	overflowStyle := lipgloss.NewStyle().Foreground(colorDimFg).Bold(true)
+
+	spaceWidth := 1 // " " between pills
+	overflowBase := lipgloss.Width(overflowStyle.Render("+99"))
+
+	// Calculate which pills to show.
+	totalPills := len(allPills)
+	if totalPills == 0 {
+		return styleStripBar.Width(width).Render("")
+	}
+
+	// Find which range of pills fits, centered on the selected pill.
+	selectedPill := selectedIdx
+	// Account for the separator being in a different position:
+	// allPills has sessions then PRs (no separator entry).
+	// We insert separator visually, not as a pill.
+	if selectedPill < 0 {
+		selectedPill = 0
+	}
+	if selectedPill >= totalPills {
+		selectedPill = totalPills - 1
+	}
+
+	// Try to fit all pills first.
+	totalWidth := 0
+	for i, p := range allPills {
+		totalWidth += p.width
+		if i > 0 {
+			totalWidth += spaceWidth
+		}
+	}
+	if hasSep {
+		totalWidth += sepWidth
+	}
+
+	if totalWidth <= budget {
+		// Everything fits — render all.
+		var pills []string
+		for i, p := range allPills {
+			if hasSep && i == len(sessions) {
+				pills = append(pills, sepStr)
+			}
+			pills = append(pills, p.rendered)
+		}
+		row := lipgloss.JoinHorizontal(lipgloss.Center, interleave(pills, " ")...)
+		return styleStripBar.Width(width).Render(row)
+	}
+
+	// Not everything fits — build a visible window around the selected pill.
+	// Start with the selected pill and expand outward.
+	visStart := selectedPill
+	visEnd := selectedPill // inclusive
+
+	usedWidth := allPills[selectedPill].width
+
+	// Expand alternately left and right.
+	for {
+		expanded := false
+		// Try right.
+		if visEnd+1 < totalPills {
+			nextW := allPills[visEnd+1].width + spaceWidth
+			// Account for separator if crossing the boundary.
+			if hasSep && visEnd+1 == len(sessions) {
+				nextW += sepWidth
+			}
+			// Reserve space for left overflow indicator.
+			leftOverflow := 0
+			if visStart > 0 {
+				leftOverflow = overflowBase + spaceWidth
+			}
+			rightOverflow := 0
+			if visEnd+2 < totalPills {
+				rightOverflow = overflowBase + spaceWidth
+			}
+			if usedWidth+nextW+leftOverflow+rightOverflow <= budget {
+				visEnd++
+				usedWidth += nextW
+				expanded = true
+			}
+		}
+		// Try left.
+		if visStart-1 >= 0 {
+			nextW := allPills[visStart-1].width + spaceWidth
+			if hasSep && visStart == len(sessions) {
+				nextW += sepWidth
+			}
+			leftOverflow := 0
+			if visStart-2 >= 0 {
+				leftOverflow = overflowBase + spaceWidth
+			}
+			rightOverflow := 0
+			if visEnd+1 < totalPills {
+				rightOverflow = overflowBase + spaceWidth
+			}
+			if usedWidth+nextW+leftOverflow+rightOverflow <= budget {
+				visStart--
+				usedWidth += nextW
+				expanded = true
+			}
+		}
+		if !expanded {
+			break
+		}
+	}
+
+	// Build visible pills with overflow indicators.
+	var pills []string
+	if visStart > 0 {
+		pills = append(pills, overflowStyle.Render(fmt.Sprintf("+%d", visStart)))
+	}
+	for i := visStart; i <= visEnd; i++ {
+		if hasSep && i == len(sessions) && visStart <= len(sessions)-1 {
+			pills = append(pills, sepStr)
+		}
+		pills = append(pills, allPills[i].rendered)
+	}
+	if visEnd < totalPills-1 {
+		pills = append(pills, overflowStyle.Render(fmt.Sprintf("+%d", totalPills-1-visEnd)))
 	}
 
 	row := lipgloss.JoinHorizontal(lipgloss.Center, interleave(pills, " ")...)
@@ -46,7 +232,14 @@ func renderUnifiedStrip(sessions []client.Session, prs []client.TrackedPR, selec
 // renderPRPill renders a single PR pill in the strip.
 func renderPRPill(p client.TrackedPR, selected bool) string {
 	icon := prPillIcon(p.State)
-	label := fmt.Sprintf("%s #%d %s", icon, p.Number, truncateMiddle(p.Title, 15))
+
+	// For merged PRs, just show "#N" since the title no longer matters.
+	var label string
+	if p.State == "merged" || p.State == "closed" {
+		label = fmt.Sprintf("%s #%d", icon, p.Number)
+	} else {
+		label = fmt.Sprintf("%s #%d %s", icon, p.Number, truncateWordBoundary(p.Title, 15))
+	}
 
 	sc := prStateColor(p.State)
 
@@ -69,17 +262,17 @@ func renderPRPill(p client.TrackedPR, selected bool) string {
 func prPillIcon(state string) string {
 	switch state {
 	case "checks_failing":
-		return "✗"
+		return "\u2717"
 	case "checks_running":
-		return "⏳"
+		return "\u23f3"
 	case "checks_passing":
-		return "✓"
+		return "\u2713"
 	case "approved":
-		return "✅"
+		return "\u2713"
 	case "merged":
-		return "🚀"
+		return "\u2713"
 	default:
-		return "•"
+		return "\u2022"
 	}
 }
 
@@ -112,6 +305,92 @@ func truncateMiddle(s string, maxLen int) string {
 	}
 	half := (maxLen - 3) / 2
 	return string(runes[:half]) + "\u2026" + string(runes[len(runes)-half:])
+}
+
+// truncateWordBoundary truncates a string at a word boundary if it exceeds maxLen.
+// Unlike truncateMiddle, it avoids cutting mid-word.
+func truncateWordBoundary(s string, maxLen int) string {
+	if maxLen <= 0 {
+		return ""
+	}
+	runes := []rune(s)
+	if len(runes) <= maxLen {
+		return s
+	}
+	if maxLen < 4 {
+		return string(runes[:maxLen])
+	}
+	// Find the last space before maxLen-1 (leaving room for ellipsis).
+	cutoff := maxLen - 1
+	lastSpace := -1
+	for i := cutoff; i >= 0; i-- {
+		if runes[i] == ' ' || runes[i] == '-' || runes[i] == '/' {
+			lastSpace = i
+			break
+		}
+	}
+	if lastSpace > maxLen/3 {
+		return strings.TrimRight(string(runes[:lastSpace]), " ") + "\u2026"
+	}
+	// No good break point — just truncate.
+	return string(runes[:maxLen-1]) + "\u2026"
+}
+
+// stripXMLTags removes XML/HTML tags from a string (e.g. <task-notification>).
+var xmlTagRe = regexp.MustCompile(`<[^>]+>`)
+
+func stripXMLTags(s string) string {
+	return xmlTagRe.ReplaceAllString(s, "")
+}
+
+// containsCCInternalMarkup returns true if the string looks like CC internal
+// messaging (task notifications, etc.) that should be filtered out.
+func containsCCInternalMarkup(s string) bool {
+	return strings.Contains(s, "<task-") || strings.Contains(s, "<tool_") ||
+		strings.Contains(s, "</task-") || strings.Contains(s, "<notification")
+}
+
+// stripMarkdown removes common markdown formatting from a string:
+// **, ##, |, table dividers (---|---), etc.
+func stripMarkdown(s string) string {
+	// Remove bold/italic markers.
+	s = strings.ReplaceAll(s, "**", "")
+	s = strings.ReplaceAll(s, "__", "")
+	// Remove heading markers.
+	lines := strings.Split(s, "\n")
+	var cleaned []string
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		// Skip pure table divider lines (---|---|---).
+		if len(trimmed) > 0 && isTableDivider(trimmed) {
+			continue
+		}
+		// Strip leading ## markers.
+		for strings.HasPrefix(trimmed, "#") {
+			trimmed = strings.TrimPrefix(trimmed, "#")
+		}
+		trimmed = strings.TrimSpace(trimmed)
+		// Strip leading/trailing pipe characters (table rows).
+		if strings.HasPrefix(trimmed, "|") && strings.HasSuffix(trimmed, "|") {
+			trimmed = strings.Trim(trimmed, "| ")
+			// Replace inner pipes with commas for readability.
+			trimmed = strings.ReplaceAll(trimmed, " | ", ", ")
+			trimmed = strings.ReplaceAll(trimmed, "|", ", ")
+		}
+		if trimmed != "" {
+			cleaned = append(cleaned, trimmed)
+		}
+	}
+	return strings.Join(cleaned, " ")
+}
+
+// isTableDivider returns true if a line is a markdown table divider like ---|---|---.
+func isTableDivider(s string) bool {
+	s = strings.ReplaceAll(s, "-", "")
+	s = strings.ReplaceAll(s, "|", "")
+	s = strings.ReplaceAll(s, ":", "")
+	s = strings.TrimSpace(s)
+	return s == ""
 }
 
 // countPending returns the total pending tools across all sessions.

--- a/tui/internal/tui/strip_test.go
+++ b/tui/internal/tui/strip_test.go
@@ -147,15 +147,15 @@ func TestPillName_Priority(t *testing.T) {
 		t.Errorf("auto slug + clean tab: got %q, want 'CSM'", got)
 	}
 
-	// Command-like tab name falls back to auto slug
+	// Command-like tab name falls back to project name (not auto slug)
 	s3 := client.Session{
 		SessionID:   "abc12345xyz",
 		Slug:        "zesty-dreaming-kitten",
 		GhosttyTab:  "cd /foo && bar",
 		ProjectName: "fallback",
 	}
-	if got := pillName(s3); got != "zesty-dreaming-kitten" {
-		t.Errorf("command tab: got %q, want auto slug", got)
+	if got := pillName(s3); got != "fallback" {
+		t.Errorf("command tab: got %q, want 'fallback'", got)
 	}
 
 	// No slug, no tab → project name
@@ -300,8 +300,8 @@ func TestPRPillIcon(t *testing.T) {
 		{"checks_failing", "\u2717"},
 		{"checks_running", "\u23f3"},
 		{"checks_passing", "\u2713"},
-		{"approved", "\u2705"},
-		{"merged", "\U0001f680"},
+		{"approved", "\u2713"},
+		{"merged", "\u2713"},
 		{"unknown", "\u2022"},
 	}
 	for _, tt := range tests {
@@ -377,5 +377,220 @@ func TestPadRight(t *testing.T) {
 		if got := padRight(tt.s, tt.w); got != tt.want {
 			t.Errorf("padRight(%q, %d) = %q, want %q", tt.s, tt.w, got, tt.want)
 		}
+	}
+}
+
+// === UX polish: strip overflow ===
+
+func TestRenderUnifiedStrip_OverflowIndicator(t *testing.T) {
+	// With many sessions at narrow width, strip should show overflow indicator.
+	var sessions []client.Session
+	for i := 0; i < 10; i++ {
+		sessions = append(sessions, client.Session{
+			SessionID:   "s" + itoa(i),
+			State:       "running",
+			ProjectName: "project-number-" + itoa(i),
+			PID:         1000 + i,
+		})
+	}
+
+	out := renderUnifiedStrip(sessions, nil, 0, 60, 0)
+	h := lipgloss.Height(out)
+	// Strip must remain a single content line (plus border).
+	if h > 2 {
+		t.Errorf("overflow strip height = %d, want <= 2 (should cap pills, not wrap)", h)
+	}
+}
+
+func TestRenderUnifiedStrip_SelectedAlwaysVisible(t *testing.T) {
+	// Even with overflow, selected pill must be visible.
+	var sessions []client.Session
+	for i := 0; i < 10; i++ {
+		sessions = append(sessions, client.Session{
+			SessionID:   "s" + itoa(i),
+			State:       "running",
+			ProjectName: "proj-" + itoa(i),
+			PID:         1000 + i,
+		})
+	}
+
+	// Select last session.
+	out := renderUnifiedStrip(sessions, nil, 9, 60, 0)
+	// Should contain the selected session name.
+	if !strings.Contains(out, "proj-9") {
+		t.Error("selected pill should be visible even with overflow")
+	}
+}
+
+// === UX polish: disambiguate names ===
+
+func TestDisambiguateNames_NoDuplicates(t *testing.T) {
+	sessions := []client.Session{
+		{SessionID: "s1", ProjectName: "alpha", PID: 100},
+		{SessionID: "s2", ProjectName: "beta", PID: 200},
+	}
+	names := disambiguateNames(sessions)
+	if names["s1"] != "alpha" {
+		t.Errorf("unique name: got %q, want 'alpha'", names["s1"])
+	}
+	if names["s2"] != "beta" {
+		t.Errorf("unique name: got %q, want 'beta'", names["s2"])
+	}
+}
+
+func TestDisambiguateNames_WithDuplicates(t *testing.T) {
+	sessions := []client.Session{
+		{SessionID: "s1", ProjectName: "my-project", PID: 100},
+		{SessionID: "s2", ProjectName: "my-project", PID: 200},
+		{SessionID: "s3", ProjectName: "unique", PID: 300},
+	}
+	names := disambiguateNames(sessions)
+
+	// Duplicates should have disambiguators.
+	if names["s1"] == names["s2"] {
+		t.Errorf("duplicate names should be disambiguated: s1=%q s2=%q", names["s1"], names["s2"])
+	}
+	// Both should contain the original name.
+	if !strings.Contains(names["s1"], "my-project") {
+		t.Errorf("disambiguated name should contain original: %q", names["s1"])
+	}
+	if !strings.Contains(names["s2"], "my-project") {
+		t.Errorf("disambiguated name should contain original: %q", names["s2"])
+	}
+	// Unique name unchanged.
+	if names["s3"] != "unique" {
+		t.Errorf("unique name should not change: got %q", names["s3"])
+	}
+}
+
+func TestDisambiguateNames_PIDSuffix(t *testing.T) {
+	sessions := []client.Session{
+		{SessionID: "s1", ProjectName: "project", PID: 12345},
+		{SessionID: "s2", ProjectName: "project", PID: 67890},
+	}
+	names := disambiguateNames(sessions)
+	if !strings.Contains(names["s1"], "12345") {
+		t.Errorf("expected PID in disambiguated name: %q", names["s1"])
+	}
+	if !strings.Contains(names["s2"], "67890") {
+		t.Errorf("expected PID in disambiguated name: %q", names["s2"])
+	}
+}
+
+// === UX polish: truncateWordBoundary ===
+
+func TestTruncateWordBoundary_ShortString(t *testing.T) {
+	if got := truncateWordBoundary("hello", 10); got != "hello" {
+		t.Errorf("short string: got %q, want 'hello'", got)
+	}
+}
+
+func TestTruncateWordBoundary_BreaksAtWord(t *testing.T) {
+	got := truncateWordBoundary("Fix the broken thing in production", 15)
+	// Should break at a word boundary, not mid-word.
+	if strings.Contains(got, "produ") && !strings.Contains(got, "production") {
+		t.Errorf("should not cut mid-word: got %q", got)
+	}
+	if !strings.HasSuffix(got, "\u2026") {
+		t.Errorf("truncated string should end with ellipsis: %q", got)
+	}
+}
+
+func TestTruncateWordBoundary_Empty(t *testing.T) {
+	if got := truncateWordBoundary("", 10); got != "" {
+		t.Errorf("empty string: got %q", got)
+	}
+}
+
+func TestTruncateWordBoundary_Zero(t *testing.T) {
+	if got := truncateWordBoundary("hello", 0); got != "" {
+		t.Errorf("zero max: got %q", got)
+	}
+}
+
+// === UX polish: XML/markdown stripping ===
+
+func TestStripXMLTags(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"hello world", "hello world"},
+		{"<task-notification>msg</task-notification>", "msg"},
+		{"<task-id>a6b241f</task-id>", "a6b241f"},
+		{"<to", "<to"}, // unclosed tag preserved
+		{"some <b>bold</b> text", "some bold text"},
+		{"no tags", "no tags"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := stripXMLTags(tt.input); got != tt.want {
+				t.Errorf("stripXMLTags(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainsCCInternalMarkup(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"normal text", false},
+		{"<task-notification>stuff</task-notification>", true},
+		{"<task-id>abc</task-id>", true},
+		{"something </task-result>", true},
+		{"Edit: main.go", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := containsCCInternalMarkup(tt.input); got != tt.want {
+				t.Errorf("containsCCInternalMarkup(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripMarkdown(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"bold", "**8 notes**, 3 enriched**", "8 notes, 3 enriched"},
+		{"heading", "## Batch Results", "Batch Results"},
+		{"table row", "| Session | Date | Notes |", "Session, Date, Notes"},
+		{"table divider", "---|---|---", ""},
+		{"plain", "no formatting", "no formatting"},
+		{"mixed", "## Title\n**bold** text", "Title bold text"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripMarkdown(tt.input)
+			if got != tt.want {
+				t.Errorf("stripMarkdown(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+// === UX polish: merged PR pill ===
+
+func TestRenderPRPill_MergedShowsJustNumber(t *testing.T) {
+	pr := client.TrackedPR{
+		Owner:  "o",
+		Repo:   "r",
+		Number: 19,
+		Title:  "Fix #17: stale pending + coverage sweep (all packages 80%+)",
+		State:  "merged",
+	}
+	pill := renderPRPill(pr, false)
+	// Should NOT contain the title for merged PRs.
+	if strings.Contains(pill, "stale") || strings.Contains(pill, "coverage") {
+		t.Error("merged PR pill should not show title, just #number")
+	}
+	// Should contain the number.
+	if !strings.Contains(pill, "#19") {
+		t.Error("merged PR pill should show #number")
 	}
 }

--- a/tui/internal/tui/zoom.go
+++ b/tui/internal/tui/zoom.go
@@ -103,17 +103,24 @@ func renderZoom(s client.Session, width, height int, scrollOffset int) string {
 	// Activities
 	if len(s.Activities) > 0 {
 		bodyLines = append(bodyLines, styleSectionLabel.Render("\u2500\u2500 Activities"))
+		// Filter out CC internal markup activities.
+		var filtered []client.Activity
+		for _, a := range s.Activities {
+			if !containsCCInternalMarkup(a.Summary) {
+				filtered = append(filtered, a)
+			}
+		}
 		start := 0
 		overflow := 0
-		if len(s.Activities) > 8 {
-			overflow = len(s.Activities) - 8
+		if len(filtered) > 8 {
+			overflow = len(filtered) - 8
 			start = overflow
 		}
 		if overflow > 0 {
 			bodyLines = append(bodyLines, lipgloss.NewStyle().Foreground(colorSubtle).
 				Render(fmt.Sprintf("  … +%d more", overflow)))
 		}
-		visible := s.Activities[start:]
+		visible := filtered[start:]
 		total := len(visible)
 		for idx, a := range visible {
 			age := total - 1 - idx
@@ -130,8 +137,14 @@ func renderZoom(s client.Session, width, height int, scrollOffset int) string {
 				Render(a.Timestamp.Format("15:04:05"))
 			icon := lipgloss.NewStyle().Foreground(activityColor(a.ActivityType)).
 				Render(activityIcon(a.ActivityType))
+			// Strip any remaining XML tags from summaries.
+			cleanSummary := stripXMLTags(a.Summary)
+			cleanSummary = strings.TrimSpace(cleanSummary)
+			if cleanSummary == "" {
+				continue
+			}
 			summary := lipgloss.NewStyle().Foreground(sumColor).
-				Render(truncateMiddle(a.Summary, innerWidth-20))
+				Render(truncateMiddle(cleanSummary, innerWidth-20))
 			bodyLines = append(bodyLines, fmt.Sprintf("  %s  %s  %s", ts, icon, summary))
 		}
 	}
@@ -140,10 +153,13 @@ func renderZoom(s client.Session, width, height int, scrollOffset int) string {
 	if s.LastText != "" {
 		bodyLines = append(bodyLines, sep)
 		bodyLines = append(bodyLines, styleSectionLabel.Render("\u2500\u2500 Last Output"))
-		text := s.LastText
-		wrapped := lipgloss.NewStyle().Width(innerWidth).Render("  \u201c" + text + "\u201d")
-		for _, wl := range strings.Split(wrapped, "\n") {
-			bodyLines = append(bodyLines, styleMotivation.Render(wl))
+		text := stripMarkdown(stripXMLTags(s.LastText))
+		text = strings.TrimSpace(text)
+		if text != "" {
+			wrapped := lipgloss.NewStyle().Width(innerWidth).Render("  \u201c" + text + "\u201d")
+			for _, wl := range strings.Split(wrapped, "\n") {
+				bodyLines = append(bodyLines, styleMotivation.Render(wl))
+			}
 		}
 	}
 

--- a/tui/internal/tui/zoom_test.go
+++ b/tui/internal/tui/zoom_test.go
@@ -296,6 +296,71 @@ func TestRenderZoom_AutopilotModes(t *testing.T) {
 	}
 }
 
+// === UX polish: XML/markdown stripping in zoom ===
+
+func TestRenderZoom_StripsXMLFromActivities(t *testing.T) {
+	now := time.Now()
+	s := client.Session{
+		SessionID: "test-1234",
+		CWD:       "/a",
+		State:     "running",
+		PID:       1,
+		Activities: []client.Activity{
+			{Timestamp: now, ActivityType: "text", Summary: "<task-notification><task-id>abc</task-id></task-notification>"},
+			{Timestamp: now, ActivityType: "tool_use", Summary: "Edit: main.go"},
+		},
+		LastActivity: &now,
+	}
+
+	out := renderZoom(s, 100, 20, 0)
+	// The CC internal message should be filtered out entirely.
+	if strings.Contains(out, "<task-") {
+		t.Error("zoom should filter CC internal markup from activities")
+	}
+	// The real activity should still be visible.
+	if !strings.Contains(out, "Edit: main.go") {
+		t.Error("real activities should remain visible")
+	}
+}
+
+func TestRenderZoom_StripsMarkdownFromLastText(t *testing.T) {
+	now := time.Now()
+	s := client.Session{
+		SessionID:    "test-1234",
+		CWD:          "/a",
+		State:        "running",
+		PID:          1,
+		LastText:     "**8 notes**, 3 enriched**",
+		LastActivity: &now,
+	}
+
+	out := renderZoom(s, 100, 20, 0)
+	if strings.Contains(out, "**") {
+		t.Error("zoom should strip markdown ** from LastText")
+	}
+	// The cleaned text should still be present.
+	if !strings.Contains(out, "8 notes") {
+		t.Error("cleaned text should contain '8 notes'")
+	}
+}
+
+func TestRenderZoom_StripsXMLFromLastText(t *testing.T) {
+	now := time.Now()
+	s := client.Session{
+		SessionID:    "test-1234",
+		CWD:          "/a",
+		State:        "running",
+		PID:          1,
+		LastText:     "Result: <b>success</b>",
+		LastActivity: &now,
+	}
+
+	out := renderZoom(s, 100, 20, 0)
+	if strings.Contains(out, "<b>") {
+		t.Error("zoom should strip XML tags from LastText")
+	}
+}
+
 func TestFullView_NeverExceedsTerminalHeight(t *testing.T) {
 	now := time.Now()
 	sessions := []client.Session{


### PR DESCRIPTION
## All 8 issues from screenshots fixed

### 1. Strip overflow (pills wrapping)
Measures total pill width vs terminal. Shows centered window around selected pill with `+N` overflow indicators. Selected always visible.

### 2. Raw XML tags in activities  
Filters out CC internal markup (`<task-*>` entries) entirely. Strips remaining XML tags from summaries.

### 3. Duplicate session names
`disambiguateNames()` detects collisions, appends `:PID` suffix to distinguish.

### 4. Markdown in Last Output
Strips `**`, `##`, table pipes from LastText before display.

### 5. PR title truncation
Word-boundary truncation (no mid-word cuts). Merged PRs show just `#N`.

### 6. Status bar "..." dots
Width-aware: falls back to essential-only rendering when line exceeds terminal.

### 7. Hints clarity
PR hint: "Enter open PR" instead of "Enter open".

### 8. Merged PR badge
Dim gray instead of hard-to-read magenta.

## Tests
18 new tests covering overflow, disambiguation, truncation, stripping, colors.

## Test plan
- [x] All tests pass
- [x] TUI + daemon build