### PR TITLE
Fix PostToolUse: tool_response is JSON object

### DIFF
--- a/daemon/internal/hookserver/handler.go
+++ b/daemon/internal/hookserver/handler.go
@@ -23,7 +23,7 @@ type hookRequest struct {
 	CWD            string         `json:"cwd"`
 	ToolName       string         `json:"tool_name"`
 	ToolInput      map[string]any `json:"tool_input"`
-	ToolOutput     string         `json:"tool_output"`
+	ToolResponse   json.RawMessage `json:"tool_response"`
 	PermissionMode string         `json:"permission_mode"`
 }
 
@@ -186,10 +186,16 @@ func (h *Handler) handlePreToolUse(req hookRequest) hookResponse {
 }
 
 func (h *Handler) handlePostToolUse(req hookRequest) {
-	if h.prPoll == nil || req.ToolOutput == "" {
+	if h.prPoll == nil {
 		return
 	}
-	url := prURLRe.FindString(req.ToolOutput)
+	// tool_response is a JSON object — search its raw bytes for PR URLs.
+	searchText := string(req.ToolResponse)
+	log.Printf("hook: PostToolUse session=%s tool=%s response_len=%d", req.SessionID, req.ToolName, len(searchText))
+	if searchText == "" {
+		return
+	}
+	url := prURLRe.FindString(searchText)
 	if url == "" {
 		return
 	}

--- a/daemon/internal/hookserver/hookserver_extra_test.go
+++ b/daemon/internal/hookserver/hookserver_extra_test.go
@@ -236,7 +236,7 @@ func TestPostToolUseNoPRPoller(t *testing.T) {
 	h.handlePostToolUse(hookRequest{
 		HookEventName: "PostToolUse",
 		SessionID:     "s1",
-		ToolOutput:    "https://github.com/owner/repo/pull/42",
+		ToolResponse: json.RawMessage(`{"stdout":"https://github.com/owner/repo/pull/42"}`),
 	})
 }
 
@@ -251,7 +251,7 @@ func TestPostToolUseEmptyOutput(t *testing.T) {
 	h.handlePostToolUse(hookRequest{
 		HookEventName: "PostToolUse",
 		SessionID:     "s1",
-		ToolOutput:    "",
+		ToolResponse: json.RawMessage(`{"stdout":""}`),
 	})
 
 	// Should not add any PR.
@@ -271,7 +271,7 @@ func TestPostToolUseNoPRURL(t *testing.T) {
 	h.handlePostToolUse(hookRequest{
 		HookEventName: "PostToolUse",
 		SessionID:     "s1",
-		ToolOutput:    "File created at /tmp/test.go",
+		ToolResponse: json.RawMessage(`{"stdout":"File created at /tmp/test.go"}`),
 	})
 
 	if len(p.GetAll()) != 0 {
@@ -289,7 +289,7 @@ func TestPostToolUseWithPRURL(t *testing.T) {
 	h.handlePostToolUse(hookRequest{
 		HookEventName: "PostToolUse",
 		SessionID:     "s1",
-		ToolOutput:    "Created PR: https://github.com/octocat/hello/pull/42",
+		ToolResponse: json.RawMessage(`{"stdout":"Created PR: https://github.com/octocat/hello/pull/42"}`),
 	})
 
 	// Give the goroutine a moment to start Poll (it will fail but we don't care).
@@ -385,7 +385,7 @@ func TestHTTPServerHandleHook_AllEvents(t *testing.T) {
 	postTo(t, ts.URL+"/hooks", hookRequest{
 		HookEventName: "PostToolUse",
 		SessionID:     "s1",
-		ToolOutput:    "PR: https://github.com/test/repo/pull/99",
+		ToolResponse: json.RawMessage(`{"stdout":"PR: https://github.com/test/repo/pull/99"}`),
 	})
 
 	time.Sleep(50 * time.Millisecond)
@@ -811,7 +811,7 @@ func TestHandlePostToolUseViaSocket(t *testing.T) {
 	req := hookRequest{
 		HookEventName: "PostToolUse",
 		SessionID:     "s1",
-		ToolOutput:    "PR created: https://github.com/test/repo/pull/1",
+		ToolResponse: json.RawMessage(`{"stdout":"PR created: https://github.com/test/repo/pull/1"}`),
 	}
 	data, _ := json.Marshal(req)
 	conn.Write(append(data, '\n'))


### PR DESCRIPTION
CC sends tool_response as JSON object, not string. Changed to json.RawMessage, regex searches raw bytes for PR URLs. Tests updated.